### PR TITLE
compensate for newer (undocumented) firmware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,19 @@
 repos:
-  - repo: https://github.com/python/black
-    rev: 23.11.0
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.11.4
     hooks:
+      # Run the linter.
       - id: ruff
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         name: mypy (library code)

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,13 @@
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "latest"
 
 python:
   install:

--- a/circuitpython_cirque_pinnacle.py
+++ b/circuitpython_cirque_pinnacle.py
@@ -215,6 +215,8 @@ class PinnacleTouch:
           is non-operational
         - :py:meth:`~circuitpython_cirque_pinnacle.PinnacleTouch.tune_edge_sensitivity()`
           is non-operational
+        - :py:meth:`~circuitpython_cirque_pinnacle.PinnacleTouch.set_adc_gain()`
+          is non-operational
         - :py:attr:`~circuitpython_cirque_pinnacle.PinnacleTouch.calibration_matrix`
           is non-operational
 

--- a/circuitpython_cirque_pinnacle.py
+++ b/circuitpython_cirque_pinnacle.py
@@ -182,7 +182,7 @@ class PinnacleTouch:
             self.dr_pin.switch_to_input()
         firmware_id, firmware_ver = self._rap_read_bytes(_FIRMWARE_ID, 2)
         self._rev2025: bool = firmware_id == 0x0E and firmware_ver == 0x75
-        if not self._rev2025 or (firmware_id, firmware_ver) != (7, 0x3A):
+        if not self._rev2025 and (firmware_id, firmware_ver) != (7, 0x3A):
             raise RuntimeError("Cirque Pinnacle ASIC not responding")
         self._intellimouse = False
         self._mode = PINNACLE_RELATIVE
@@ -206,7 +206,7 @@ class PinnacleTouch:
     def rev2025(self) -> bool:
         """Is this trackpad using a newer firmware version?
 
-        This read-only property describes if the trackpad used has a firmware revision
+        This read-only property describes if the Pinnacle ASIC uses a firmware revision
         that was deployed on or around 2025. Consequently, some advanced configuration
         is not possible with this undocumented firmware revision.
         Thus, the following functionality is affected on the trackpads when this
@@ -480,7 +480,8 @@ class PinnacleTouch:
         """This attribute controls how many samples (of data) per second are reported.
 
         Valid values are ``100``, ``80``, ``60``, ``40``, ``20``, ``10``. Any other
-        input values automatically set the sample rate to 100 sps (samples per second).
+        input values automatically set the sample rate to ``100`` sps (samples per
+        second).
 
         Optionally (on older trackpads), ``200`` and ``300`` sps can be specified, but
         using these values automatically disables palm (referred to as "NERD" in the
@@ -538,7 +539,7 @@ class PinnacleTouch:
             Consider adjusting the ADC matrix's gain to enhance performance/results
             using `set_adc_gain()`
         """
-        if not self._rev2025:
+        if self._rev2025:
             return
         finger_stylus = self._era_read(0x00EB)
         finger_stylus |= (enable_stylus << 2) | enable_finger

--- a/circuitpython_cirque_pinnacle.py
+++ b/circuitpython_cirque_pinnacle.py
@@ -873,10 +873,16 @@ class PinnacleTouch:
         prev_feed_state = self.feed_enable
         if prev_feed_state:
             self.feed_enable = False  # accessing raw memory, so do this
+        if self._rev2025:
+            self.clear_status_flags()
         self._rap_write_bytes(_ERA_ADDR, bytes([reg >> 8, reg & 0xFF]))
         self._rap_write(_ERA_CONTROL, 1)  # indicate reading only 1 byte
-        while self._rap_read(_ERA_CONTROL):  # read until reg == 0
-            pass  # also sets Command Complete flag in Status register
+        if self._rev2025:
+            while not self.dr_pin.value:  # wait for command to complete
+                pass
+        else:
+            while self._rap_read(_ERA_CONTROL):  # read until reg == 0
+                pass  # also sets Command Complete flag in Status register
         buf = self._rap_read(_ERA_VALUE)  # get value
         self.clear_status_flags()
         if prev_feed_state:
@@ -888,11 +894,17 @@ class PinnacleTouch:
         prev_feed_state = self.feed_enable
         if prev_feed_state:
             self.feed_enable = False  # accessing raw memory, so do this
+        if self._rev2025:
+            self.clear_status_flags()
         self._rap_write_bytes(_ERA_ADDR, bytes([reg >> 8, reg & 0xFF]))
         for _ in range(numb_bytes):
             self._rap_write(_ERA_CONTROL, 5)  # indicate reading sequential bytes
-            while self._rap_read(_ERA_CONTROL):  # read until reg == 0
-                pass  # also sets Command Complete flag in Status register
+            if self._rev2025:
+                while not self.dr_pin.value:  # wait for command to complete
+                    pass
+            else:
+                while self._rap_read(_ERA_CONTROL):  # read until reg == 0
+                    pass  # also sets Command Complete flag in Status register
             buf += bytes([self._rap_read(_ERA_VALUE)])  # get value
             self.clear_status_flags()
         if prev_feed_state:
@@ -903,11 +915,17 @@ class PinnacleTouch:
         prev_feed_state = self.feed_enable
         if prev_feed_state:
             self.feed_enable = False  # accessing raw memory, so do this
+        if self._rev2025:
+            self.clear_status_flags()
         self._rap_write(_ERA_VALUE, value)  # write value
         self._rap_write_bytes(_ERA_ADDR, bytes([reg >> 8, reg & 0xFF]))
         self._rap_write(_ERA_CONTROL, 2)  # indicate writing only 1 byte
-        while self._rap_read(_ERA_CONTROL):  # read until reg == 0
-            pass  # also sets Command Complete flag in Status register
+        if self._rev2025:
+            while not self.dr_pin.value:  # wait for command to complete
+                pass
+        else:
+            while self._rap_read(_ERA_CONTROL):  # read until reg == 0
+                pass  # also sets Command Complete flag in Status register
         self.clear_status_flags()
         if prev_feed_state:
             self.feed_enable = prev_feed_state  # resume previous feed state
@@ -917,12 +935,18 @@ class PinnacleTouch:
         prev_feed_state = self.feed_enable
         if prev_feed_state:
             self.feed_enable = False  # accessing raw memory, so do this
+        if self._rev2025:
+            self.clear_status_flags()
         self._rap_write(_ERA_VALUE, value)  # write value
         self._rap_write_bytes(_ERA_ADDR, bytes([reg >> 8, reg & 0xFF]))
         self._rap_write(_ERA_CONTROL, 0x0A)  # indicate writing sequential bytes
         for _ in range(numb_bytes):
-            while self._rap_read(_ERA_CONTROL):  # read until reg == 0
-                pass  # also sets Command Complete flag in Status register
+            if self._rev2025:
+                while not self.dr_pin.value:  # wait for command to complete
+                    pass
+            else:
+                while self._rap_read(_ERA_CONTROL):  # read until reg == 0
+                    pass  # also sets Command Complete flag in Status register
             self.clear_status_flags()
         if prev_feed_state:
             self.feed_enable = prev_feed_state  # resume previous feed state

--- a/circuitpython_cirque_pinnacle.py
+++ b/circuitpython_cirque_pinnacle.py
@@ -932,12 +932,12 @@ class PinnacleTouchI2C(PinnacleTouch):
 
     :param i2c: The object of the I2C bus to use. This object must be shared among other
         driver classes that use the same I2C bus (SDA & SCL pins).
-    :param address: The slave I2C address of the Pinnacle ASIC. Defaults to ``0x2A``.
     :param dr_pin: |dr_pin_parameter|
 
         .. versionchanged:: 2.0.0 ``dr_pin`` is a required parameter.
 
             |dr_pin_required|
+    :param address: The slave I2C address of the Pinnacle ASIC. Defaults to ``0x2A``.
     """
 
     def __init__(
@@ -983,12 +983,12 @@ class PinnacleTouchSPI(PinnacleTouch):
     :param spi: The object of the SPI bus to use. This object must be shared among other
         driver classes that use the same SPI bus (MOSI, MISO, & SCK pins).
     :param ss_pin: The "slave select" pin output to the Pinnacle ASIC.
-    :param spi_frequency: The SPI bus speed in Hz. Default is the maximum 13 MHz.
     :param dr_pin: |dr_pin_parameter|
 
         .. versionchanged:: 2.0.0 ``dr_pin`` is a required parameter.
 
             |dr_pin_required|
+    :param spi_frequency: The SPI bus speed in Hz. Default is the maximum 13 MHz.
     """
 
     def __init__(

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -1,0 +1,23 @@
+version: "0.2"
+words:
+  - adafruit
+  - autoattribute
+  - autoclass
+  - automethod
+  - ANYMEAS
+  - ASIC
+  - baudrate
+  - busio
+  - circuitpython
+  - datasheet
+  - digitalio
+  - intellimouse
+  - micropython
+  - MOSI
+  - Muxing
+  - pipx
+  - seealso
+  - sparkfun
+  - tolower
+  - trackpad
+  - trackpads

--- a/docs/anymeas.rst
+++ b/docs/anymeas.rst
@@ -88,8 +88,8 @@ AnyMeas mode Control
 These constants control the number of measurements performed in `measure_adc()`.
 The number of measurements can range [0, 63].
 
-.. autodata:: circuitpython_cirque_pinnacle.PINNACLE_CRTL_REPEAT
+.. autodata:: circuitpython_cirque_pinnacle.PINNACLE_CTRL_REPEAT
    :no-value:
 
-.. autodata:: circuitpython_cirque_pinnacle.PINNACLE_CRTL_PWR_IDLE
+.. autodata:: circuitpython_cirque_pinnacle.PINNACLE_CTRL_PWR_IDLE
    :no-value:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,6 +19,7 @@ PinnacleTouch class
    :no-members:
 
    .. autoattribute:: circuitpython_cirque_pinnacle.PinnacleTouch.data_mode
+   .. autoattribute:: circuitpython_cirque_pinnacle.PinnacleTouch.rev2025
 
 SPI & I2C Interfaces
 --------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name,too-few-public-methods
 """This file is for `sphinx-build` configuration"""
+
 import os
 import sys
 
@@ -86,6 +87,10 @@ rst_prolog = """
    :language: python
    :class: highlight
 .. default-literal-role:: python
+
+.. |rev2025| replace:: not supported on trackpads manufactured on or after 2025.
+    Defer to :py:attr:`~circuitpython_cirque_pinnacle.PinnacleTouch.rev2025`.
+.. |rev2025-no-effect| replace:: on newer trackpads will have no effect
 """
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
@@ -112,6 +117,13 @@ html_theme_options = {
     ],
     # Set the color and the accent color
     "palette": [
+        {
+            "media": "(prefers-color-scheme)",
+            "toggle": {
+                "icon": "material/brightness-auto",
+                "name": "Switch to light mode",
+            },
+        },
         {
             "media": "(prefers-color-scheme: light)",
             "scheme": "default",

--- a/examples/cirque_pinnacle_absolute_mode.py
+++ b/examples/cirque_pinnacle_absolute_mode.py
@@ -1,6 +1,7 @@
 """
 A simple example of using the Pinnacle ASIC in absolute mode.
 """
+
 import math
 import sys
 import time

--- a/examples/cirque_pinnacle_absolute_mode.py
+++ b/examples/cirque_pinnacle_absolute_mode.py
@@ -18,21 +18,18 @@ IS_ON_LINUX = sys.platform.lower() == "linux"
 
 print("Cirque Pinnacle absolute mode\n")
 
-# a HW ``dr_pin`` is more efficient, but not required for Absolute or Relative modes
-dr_pin = None
-if not input("Use SW Data Ready? [y/N] ").lower().startswith("y"):
-    print("-- Using HW Data Ready pin.")
-    dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
+# the pin connected to the trackpad's DR pin.
+dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
 
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):
     print("-- Using SPI interface.")
     spi = board.SPI()
     ss_pin = DigitalInOut(board.D2 if not IS_ON_LINUX else board.CE0)
-    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin=dr_pin)
+    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin)
 else:
     print("-- Using I2C interface.")
     i2c = board.I2C()
-    trackpad = PinnacleTouchI2C(i2c, dr_pin=dr_pin)
+    trackpad = PinnacleTouchI2C(i2c, dr_pin)
 
 trackpad.data_mode = PINNACLE_ABSOLUTE  # ensure Absolute mode is enabled
 trackpad.absolute_mode_config(z_idle_count=1)  # limit idle packet count to 1

--- a/examples/cirque_pinnacle_anymeas_mode.py
+++ b/examples/cirque_pinnacle_anymeas_mode.py
@@ -16,18 +16,18 @@ IS_ON_LINUX = sys.platform.lower() == "linux"
 
 print("Cirque Pinnacle anymeas mode\n")
 
-# Using HW Data Ready pin as required for Anymeas mode
+# the pin connected to the trackpad's DR pin.
 dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
 
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):
     print("-- Using SPI interface.")
     spi = board.SPI()
     ss_pin = DigitalInOut(board.D2 if not IS_ON_LINUX else board.CE0)
-    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin=dr_pin)
+    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin)
 else:
     print("-- Using I2C interface.")
     i2c = board.I2C()
-    trackpad = PinnacleTouchI2C(i2c, dr_pin=dr_pin)
+    trackpad = PinnacleTouchI2C(i2c, dr_pin)
 
 trackpad.data_mode = PINNACLE_ANYMEAS
 

--- a/examples/cirque_pinnacle_anymeas_mode.py
+++ b/examples/cirque_pinnacle_anymeas_mode.py
@@ -1,6 +1,7 @@
 """
 A simple example of using the Pinnacle ASIC in anymeas mode.
 """
+
 import sys
 import time
 import board

--- a/examples/cirque_pinnacle_relative_mode.py
+++ b/examples/cirque_pinnacle_relative_mode.py
@@ -1,6 +1,7 @@
 """
 A simple example of using the Pinnacle ASIC in relative mode.
 """
+
 import sys
 import time
 import board

--- a/examples/cirque_pinnacle_relative_mode.py
+++ b/examples/cirque_pinnacle_relative_mode.py
@@ -17,21 +17,18 @@ IS_ON_LINUX = sys.platform.lower() == "linux"
 
 print("Cirque Pinnacle relative mode\n")
 
-# a HW ``dr_pin`` is more efficient, but not required for Absolute or Relative modes
-dr_pin = None
-if not input("Use SW Data Ready? [y/N] ").lower().startswith("y"):
-    print("-- Using HW Data Ready pin.")
-    dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
+# the pin connected to the trackpad's DR pin.
+dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
 
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):
     print("-- Using SPI interface.")
     spi = board.SPI()
     ss_pin = DigitalInOut(board.D2 if not IS_ON_LINUX else board.CE0)
-    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin=dr_pin)
+    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin)
 else:
     print("-- Using I2C interface.")
     i2c = board.I2C()
-    trackpad = PinnacleTouchI2C(i2c, dr_pin=dr_pin)
+    trackpad = PinnacleTouchI2C(i2c, dr_pin)
 
 trackpad.data_mode = PINNACLE_RELATIVE  # ensure mouse mode is enabled
 trackpad.relative_mode_config(True)  # enable tap detection

--- a/examples/cirque_pinnacle_usb_mouse.py
+++ b/examples/cirque_pinnacle_usb_mouse.py
@@ -4,6 +4,7 @@ to emulate a mouse with the Cirque circle trackpad.
 
 NOTE: This example won't work on Linux (eg. using Raspberry Pi GPIO pins).
 """
+
 import sys
 import time
 import board

--- a/examples/cirque_pinnacle_usb_mouse.py
+++ b/examples/cirque_pinnacle_usb_mouse.py
@@ -21,21 +21,18 @@ IS_ON_LINUX = sys.platform.lower() == "linux"
 
 print("Cirque Pinnacle as a USB mouse\n")
 
-# a HW ``dr_pin`` is more efficient, but not required for Absolute or Relative modes
-dr_pin = None
-if not input("Use SW Data Ready? [y/N] ").lower().startswith("y"):
-    print("-- Using HW Data Ready pin.")
-    dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
+# the pin connected to the trackpad's DR pin.
+dr_pin = DigitalInOut(board.D7 if not IS_ON_LINUX else board.D25)
 
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):
     print("-- Using SPI interface.")
     spi = board.SPI()
     ss_pin = DigitalInOut(board.D2 if not IS_ON_LINUX else board.CE0)
-    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin=dr_pin)
+    trackpad = PinnacleTouchSPI(spi, ss_pin, dr_pin)
 else:
     print("-- Using I2C interface.")
     i2c = board.I2C()
-    trackpad = PinnacleTouchI2C(i2c, dr_pin=dr_pin)
+    trackpad = PinnacleTouchI2C(i2c, dr_pin)
 
 trackpad.data_mode = PINNACLE_RELATIVE  # ensure mouse mode is enabled
 # tell the Pinnacle ASIC to rotate the orientation of the axis data by +90 degrees

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """All setup/install info is now in pyproject.toml"""
+
 from setuptools import setup
 
 setup()


### PR DESCRIPTION
# Breaking Change
The trackpad's DataReady (DR) is now a required parameter for the constructors. 

## Support for new trackpad firmware
Introduces a new property `PinnacleTouch.rev2025`. The following functionality is affected on the trackpads where this property returns `True`:
- `sample_rate` cannot exceed 100
- `detect_finger_stylus()` is non-operational
- `tune_edge_sensitivity()` is non-operational
- `calibration_matrix` is non-operational
- `set_adc_gain()` is non-operational

## Chores
Other changes involve house keeping chores like
- spelling fixes
- pre-commit hook updates
- formatting changes
- doc updates
- RTD config updates

## Contributors 
Special thanks to @ramensum for bringing this to my attention and hardware testing.